### PR TITLE
bugfix: center align text in select for safari

### DIFF
--- a/src/components/ui/LangSwitch.vue
+++ b/src/components/ui/LangSwitch.vue
@@ -71,7 +71,6 @@ export default {
         input {
             text-align: center;
             width: 100%;
-            pointer-events: none;
 
             padding: 0.25rem 1.5rem;
             border-radius: 6px;
@@ -82,6 +81,13 @@ export default {
             -webkit-text-fill-color: #b2dfdb;
             opacity: 1; /* required on iOS */
         }
+    }
+
+    &:hover input {
+        outline: none;
+        border-color: #26a69a;
+        color: #26a69a;
+        -webkit-text-fill-color: #26a69a;
     }
 }
 </style>


### PR DESCRIPTION
Пофикшен бак центрирования текста в селекте для Safari (iOS/macOS)

Решение взято здесь: https://codepen.io/samhtfc/pen/powQVWX

Реализован "фейковый селект"
- Реальный элемент select скрывается, от него берется только возможность использовать список options
- Вывод выбранного варианта на экран происходит в input (для которого text-align работает нормально) 
- Этот инпут абсолютно позиционируется относительно select'а, чтобы нажатие на него выводило список options