### PR TITLE
bugfix: fix grouping contacts 

### DIFF
--- a/src/components/contacts/ContactsList.vue
+++ b/src/components/contacts/ContactsList.vue
@@ -80,7 +80,9 @@ export default {
     computed: {
         availableContacts() {
             const allContacts = this.$store.getters['contacts/contacts'];
-            const sortedContacts = allContacts.slice().sort((c1, c2) => (c1.name > c2.name ? 1 : -1));
+            const sortedContacts = allContacts
+                .slice()
+                .sort((c1, c2) => (c1.name.toLowerCase() > c2.name.toLowerCase() ? 1 : -1));
 
             return sortedContacts;
         },


### PR DESCRIPTION
Исправлен баг группировки контактов по первой букву (убрана чувствительность к регистру при сортировке по алфавиту)

<img width="624" alt="image" src="https://user-images.githubusercontent.com/63578811/222967384-11d520a8-c79f-440d-87a4-00f56d9656c9.png">
